### PR TITLE
Added executable path option

### DIFF
--- a/nodes/Puppeteer/Puppeteer.node.options.ts
+++ b/nodes/Puppeteer/Puppeteer.node.options.ts
@@ -607,6 +607,14 @@ export const nodeDescription: INodeTypeDescription = {
 										description: 'Whether to run browser in headless mode. Defaults to true.',
 								},
 								{
+										displayName: 'Executable path',
+										name: 'executablePath',
+										type: 'string',
+										required: false,
+										default: null,
+										description: 'A path where Puppeteer expects to find the bundled browser.',
+								},
+								{
 										displayName: 'Stealth mode',
 										name: 'stealth',
 										type: 'boolean',

--- a/nodes/Puppeteer/Puppeteer.node.ts
+++ b/nodes/Puppeteer/Puppeteer.node.ts
@@ -47,6 +47,7 @@ export class Puppeteer implements INodeType {
 		const launchArguments = (options.launchArguments as IDataObject) || {};
 		const operation = this.getNodeParameter('operation', 0) as string;
 		const headless = options.headless !== false;
+		const executablePath = options.executablePath;
 		const stealth = options.stealth === true;
 		const pageCaching = options.pageCaching !== false;
 		const launchArgs: IDataObject[] = launchArguments.args as IDataObject[];
@@ -65,8 +66,15 @@ export class Puppeteer implements INodeType {
 		if (stealth) {
 			puppeteer.use(pluginStealth());
 		}
+		const launchOptions: {headless: boolean, args: string[], executablePath?: string} = {
+			headless, args 
+		}
 
-		const browser = await puppeteer.launch({ headless, args });
+		if(executablePath) {
+			launchOptions.executablePath = executablePath as string;
+		}
+		
+		const browser = await puppeteer.launch(launchOptions);
 
 		for (let itemIndex: number = 0; itemIndex < items.length; itemIndex++) {
 			const urlString = this.getNodeParameter('url', itemIndex) as string;


### PR DESCRIPTION
## Description

I keep running into issues running the default chrome binary (EOENT spawn). I'm able to run the node defining my own browser path, but the current configuration doesn't allow for it. This PR adds `executablePath`  as an optional configuration option. 

Thank you for putting this package together - It'll be super helpful for automated workflow actions (using it to write a package tracking workflow!).


Open to feedback on the PR or discussion if this is not the direction the maintainer wants to take the package on1 