### PR TITLE
Proper status code check

### DIFF
--- a/nodes/Puppeteer/Puppeteer.node.ts
+++ b/nodes/Puppeteer/Puppeteer.node.ts
@@ -229,7 +229,7 @@ async function processPageOperation(
 		const headers = await response?.headers();
 		const statusCode = response?.status();
 
-		if (!response || statusCode !== 200) {
+		if (!response || statusCode >= 400) {
 			return handleError.call(
 				this,
 				new Error(`Request failed with status code ${statusCode || 0}`),


### PR DESCRIPTION
To fix this:
![image](https://github.com/user-attachments/assets/27324a11-4dcb-4154-845f-59cfdabb6028)

ideally, the node should not fail on any status code but return the status code with the page content

but for now, let's at least include other OK status codes for the node
