### PR TITLE
added glib for Dokploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ USER root
 RUN apk add --no-cache \
     chromium \
     nss \
+    glib \
     freetype \
     freetype-dev \
     harfbuzz \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,6 +6,7 @@ USER root
 RUN apk add --no-cache \
     chromium \
     nss \
+    glib \
     freetype \
     freetype-dev \
     harfbuzz \


### PR DESCRIPTION
Just added a glib library to Docker image because the Dokploy project need it to allow puppeteer start