### PR TITLE
Adding Headers Options for WS authentication

### DIFF
--- a/nodes/Puppeteer/Puppeteer.node.options.ts
+++ b/nodes/Puppeteer/Puppeteer.node.options.ts
@@ -549,6 +549,39 @@ export const nodeDescription: INodeTypeDescription = {
 					default: '',
 					description: 'The WebSocket URL of the browser to connect to. When configured, puppeteer will skip the browser launch and connect to the browser instance.',
 				},
+                {
+					displayName: 'Browser WebSocket Headers',
+					name: 'wsHeaders',
+					placeholder: 'Add Header',
+					type: 'fixedCollection',
+					typeOptions: {
+						multipleValues: true,
+					},
+					description: 'The headers to send when connecting to the browser websocket endpoint.',
+					default: {},
+					options: [
+						{
+							name: 'parameter',
+							displayName: 'Header',
+							values: [
+								{
+									displayName: 'Name',
+									name: 'name',
+									type: 'string',
+									default: '',
+									description: 'Name of the header.',
+								},
+								{
+									displayName: 'Value',
+									name: 'value',
+									type: 'string',
+									default: '',
+									description: 'Value to set for the header.',
+								},
+							],
+						},
+					],
+				},
 				{
 					displayName: 'Emulate Device',
 					name: 'device',

--- a/nodes/Puppeteer/Puppeteer.node.ts
+++ b/nodes/Puppeteer/Puppeteer.node.ts
@@ -478,7 +478,11 @@ export class Puppeteer implements INodeType {
 		const launchArgs: IDataObject[] = launchArguments.args as IDataObject[];
 		const args: string[] = [];
 		const device = options.device as string;
-        const wsHeaders: {} = options.wsHeaders || {};
+        const wsHeaders: HeaderObject = (options.wsHeaders  as HeaderObject) || {};
+        const mappedWSHeaders = (wsHeaders.parameter || []).reduce((acc, header) => {
+            acc[header.name] = header.value;
+            return acc;
+        }, {});
 		const protocolTimeout = options.protocolTimeout as number;
         
 		let batchSize = options.batchSize as number;
@@ -528,7 +532,7 @@ export class Puppeteer implements INodeType {
 				browser = await puppeteer.connect({
 					browserWSEndpoint,
 					protocolTimeout,
-                    headers: wsHeaders
+                    headers: mappedWSHeaders
 				});
 			} else {
 				browser = await puppeteer.launch({

--- a/nodes/Puppeteer/Puppeteer.node.ts
+++ b/nodes/Puppeteer/Puppeteer.node.ts
@@ -478,7 +478,9 @@ export class Puppeteer implements INodeType {
 		const launchArgs: IDataObject[] = launchArguments.args as IDataObject[];
 		const args: string[] = [];
 		const device = options.device as string;
+        const wsHeaders: {} = options.wsHeaders || {};
 		const protocolTimeout = options.protocolTimeout as number;
+        
 		let batchSize = options.batchSize as number;
 
 		if (!Number.isInteger(batchSize) || batchSize < 1) {
@@ -526,6 +528,7 @@ export class Puppeteer implements INodeType {
 				browser = await puppeteer.connect({
 					browserWSEndpoint,
 					protocolTimeout,
+                    headers: wsHeaders
 				});
 			} else {
 				browser = await puppeteer.launch({


### PR DESCRIPTION
Adding a new Headers option to allow users to add custom headers to the WebSocket connection (If used).

Useful if you want to connect to services like Airtop that require an authorization header with a bearer token.