### PR TITLE
Update Puppeteer.node.ts to include Locator

### DIFF
--- a/nodes/Puppeteer/Puppeteer.node.ts
+++ b/nodes/Puppeteer/Puppeteer.node.ts
@@ -23,6 +23,7 @@ import {
 	type PDFOptions,
 	type PuppeteerLifeCycleEvent,
 	type ScreenshotOptions,
+	Locator,
 } from 'puppeteer';
 
 import { nodeDescription } from './Puppeteer.node.options';


### PR DESCRIPTION
Adding Locator from puppeteer would allow the use of Locator static functions like [Locator.race()](https://pptr.dev/api/puppeteer.locator)

Motivation: 
Chrome's built in dev tools "Recorder" uses Locator.race() a lot to find elements. Which is helpful to use when using a n8n-nodes-puppeteer "Run Custom Script" function